### PR TITLE
Fix for missing returns.

### DIFF
--- a/socks.go
+++ b/socks.go
@@ -88,8 +88,10 @@ func dialSocks5(proxy, targetAddr string) (conn net.Conn, err error) {
 		return
 	} else if len(resp) != 2 {
 		err = errors.New("Server does not respond properly.")
+        return
 	} else if resp[0] != 5 {
 		err = errors.New("Server does not support Socks 5.")
+        return
 	} else if resp[1] != 0 { // no auth
 		err = errors.New("socks method negotiation failed.")
 		return
@@ -157,6 +159,7 @@ func dialSocks4(socksType int, proxy, targetAddr string) (conn net.Conn, err err
 		return
 	} else if len(resp) != 8 {
 		err = errors.New("Server does not respond properly.")
+        return
 	}
 	switch resp[1] {
 	case 90:

--- a/socks.go
+++ b/socks.go
@@ -88,10 +88,10 @@ func dialSocks5(proxy, targetAddr string) (conn net.Conn, err error) {
 		return
 	} else if len(resp) != 2 {
 		err = errors.New("Server does not respond properly.")
-        return
+		return
 	} else if resp[0] != 5 {
 		err = errors.New("Server does not support Socks 5.")
-        return
+		return
 	} else if resp[1] != 0 { // no auth
 		err = errors.New("socks method negotiation failed.")
 		return
@@ -159,7 +159,7 @@ func dialSocks4(socksType int, proxy, targetAddr string) (conn net.Conn, err err
 		return
 	} else if len(resp) != 8 {
 		err = errors.New("Server does not respond properly.")
-        return
+		return
 	}
 	switch resp[1] {
 	case 90:


### PR DESCRIPTION
Fix for error index out of bounds. 

panic: runtime error: index out of range

goroutine 46 [running]:
h12.me/socks.dialSocks4(0x0, 0x187f68e0, 0x10, 0x187f6b20, 0x10, 0xb6b91588, 0x1880e080, 0xb6b8c018, 0x1880e188)
        /root/go/src/h12.me/socks/socks.go:161 +0x982
h12.me/socks.DialSocksProxy.func2(0x8379b4c, 0x3, 0x187f6b20, 0x10, 0x0, 0x0, 0x0, 0x0)
        /root/go/src/h12.me/socks/socks.go:69 +0x60
net/http.(*Transport).dial(0x187598f0, 0x8379b4c, 0x3, 0x187f6b20, 0x10, 0x0, 0x0, 0x0, 0x0)
        /usr/lib/go/src/net/http/transport.go:499 +0x68
net/http.(*Transport).dialConn(0x187598f0, 0x0, 0x83b0f20, 0x4, 0x187f6b20, 0x10, 0x0, 0x0, 0x0)
        /usr/lib/go/src/net/http/transport.go:596 +0x1619
net/http.(*Transport).getConn.func4(0x187598f0, 0x0, 0x83b0f20, 0x4, 0x187f6b20, 0x10, 0x187fc140)
        /usr/lib/go/src/net/http/transport.go:549 +0x4d
created by net/http.(*Transport).getConn
        /usr/lib/go/src/net/http/transport.go:551 +0x20d

