### PR TITLE
allow import from github instead of h12.me/socks

### DIFF
--- a/socks.go
+++ b/socks.go
@@ -38,7 +38,7 @@ A complete example using this package:
 		return
 	}
 */
-package socks // import "h12.me/socks"
+package socks
 
 import (
 	"errors"


### PR DESCRIPTION
allow import from github instead of h12.me/socks

when importing from github got:
```
package github.com/h12w/socks: code in directory github.com/h12w/socks expects import "h12.me/socks"
```

when importing from h12.me got:
```
cd .; git clone https://h12.me/socks ./src/h12.me/socks
Cloning into './src/h12.me/socks'...
fatal: unable to access 'https://h12.me/socks/': gnutls_handshake() failed: A TLS fatal alert has been received.
```