### PR TITLE
authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ SOCKS is a SOCKS4, SOCKS4A and SOCKS5 proxy package for Go.
 ## Quick Start
 ### Get the package
 
-    go get -u "h12.io/socks"
+    go get -u "github.com/bigemon/socks"
 
 ### Import the package
 
-    import "h12.io/socks"
+    import "github.com/bigemon/socks"
 
 ### Create a SOCKS proxy dialing function
 
-    dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, "127.0.0.1:1080")
+    dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, "127.0.0.1:1080",nil)
     tr := &http.Transport{Dial: dialSocksProxy}
     httpClient := &http.Client{Transport: tr}
 
@@ -28,31 +28,49 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
+	"time"
 
-	"h12.io/socks"
+	"github.com/bigemon/socks"
 )
 
 func main() {
-	dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, "127.0.0.1:1080")
+	opt := &socks.Opt{
+		User:        "admin",
+		Password:    "123456",
+		DialTimeout: time.Second * 5,
+		Timeout:     time.Second * 15,
+	}
+	//If opt is nil, the default value will be used.       ↓↓
+	//socks.DialSocksProxy(socks.SOCKS5, "127.0.0.1:8800", nil) 
+	dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, "127.0.0.1:8800", opt)
 	tr := &http.Transport{Dial: dialSocksProxy}
 	httpClient := &http.Client{Transport: tr}
-	resp, err := httpClient.Get("http://www.google.com")
+
+	bodyText, err := TestHttpsGet(httpClient, "http://2018.ip138.com/ic.asp")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err.Error())
+	}
+	fmt.Print(bodyText)
+}
+
+func TestHttpsGet(c *http.Client, url string) (bodyText string, err error) {
+	resp, err := c.Get(url)
+	if err != nil {
+		return
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		log.Fatal(resp.StatusCode)
-	}
-	buf, err := ioutil.ReadAll(resp.Body)
+
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatal(err)
+		return
 	}
-	fmt.Println(string(buf))
+	bodyText = string(body)
+	return
 }
 ```
 
 ## Alternatives
 http://godoc.org/golang.org/x/net/proxy
+
+

--- a/socks.go
+++ b/socks.go
@@ -16,7 +16,7 @@ A complete example using this package:
 	)
 
 	func main() {
-		dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, "127.0.0.1:1080")
+		dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, "127.0.0.1:1080",nil)
 		tr := &http.Transport{Dial: dialSocksProxy}
 		httpClient := &http.Client{Transport: tr}
 
@@ -55,11 +55,12 @@ const (
 	SOCKS5
 )
 
+//Opt Some optional parameters
 type Opt struct {
 	User        string
 	Password    string
-	DialTimeout time.Duration
-	Timeout     time.Duration
+	DialTimeout time.Duration //default : 5 seconds
+	Timeout     time.Duration //default : 15 seconds
 }
 
 // DialSocksProxy returns the dial function to be used in http.Transport object.


### PR DESCRIPTION
I found that in a bad network environment, **sendReceive** lost the packet and did not respond, which caused the "**http.Transport**" process to permanently block in "**Dial**". So I set the default timeout for **sendReceive**.

In addition, support for authentication has been added.