### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module h12.io/socks
+
+go 1.9


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be adopted fully in Go 1.12. Experimental support is in Go 1.11 and the `go.mod` file is supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library has no external dependencies and is still below version 2, the `go.mod` file is fairly simple. The only other thing that would need to be done is to create a semver compatible tag after this patch is merged (eg. `v1.0.1`) to allow other things to pin to that version without having to use the special commit-based version string.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules